### PR TITLE
Add calendar export functionality for screenings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -58,7 +58,9 @@
     "pickTop5Title": "Pick your Top Films",
     "pickTop5Desc": "{count} selected — these will appear on your share card",
     "generateImage": "Generate Image",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "addToCalendar": "Add to Calendar",
+    "addToCalendarSingle": "Add to calendar"
   },
   "favourites": {
     "addFavourite": "Add to favourites",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -58,7 +58,9 @@
     "pickTop5Title": "選擇你的精選電影",
     "pickTop5Desc": "已選 {count} 部 — 將顯示在分享圖片中",
     "generateImage": "生成圖片",
-    "cancel": "取消"
+    "cancel": "取消",
+    "addToCalendar": "加入日曆",
+    "addToCalendarSingle": "加入日曆"
   },
   "favourites": {
     "addFavourite": "加入收藏",

--- a/src/components/PlanPageClient.tsx
+++ b/src/components/PlanPageClient.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { usePlan } from "@/components/PlanContext";
 import { buildExportText } from "@/components/PlanExport";
+import { generateIcsForPlan, generateIcsForScreening, downloadIcsFile } from "@/lib/icsCalendar";
 import ShareCardRenderer from "@/components/ShareCardRenderer";
 import { useShareImage } from "@/lib/useShareImage";
 import type { Film, Screening, Venue } from "@/lib/types";
@@ -146,6 +147,19 @@ export default function PlanPageClient({ screenings, films, venues, locale }: Pr
           className="bg-red-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-red-700 transition-colors disabled:opacity-40"
         >
           {isGenerating ? t("generating") : t("shareImage")}
+        </button>
+        <button
+          onClick={() => {
+            const items = planItems.map(({ screening, film, venue }) => ({
+              screening, film, venue,
+            }));
+            const ics = generateIcsForPlan(items, locale);
+            downloadIcsFile(ics, "hkiff50-plan.ics");
+          }}
+          disabled={planItems.length === 0}
+          className="bg-neutral-900 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-neutral-700 transition-colors disabled:opacity-40"
+        >
+          {t("addToCalendar")}
         </button>
         <button
           onClick={handleShare}
@@ -347,6 +361,20 @@ export default function PlanPageClient({ screenings, films, venues, locale }: Pr
                             +
                           </button>
                         </div>
+
+                        <button
+                          onClick={() => {
+                            const ics = generateIcsForScreening(screening, film, venue, locale);
+                            downloadIcsFile(ics, `hkiff50-${screening.screeningCode}.ics`);
+                          }}
+                          aria-label={t("addToCalendarSingle")}
+                          title={t("addToCalendarSingle")}
+                          className="text-neutral-400 hover:text-blue-600 transition-colors leading-none"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                            <path fillRule="evenodd" d="M5.75 2a.75.75 0 0 1 .75.75V4h7V2.75a.75.75 0 0 1 1.5 0V4H17a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h2.25V2.75A.75.75 0 0 1 5.75 2zM4 7.5v8.5h12V7.5H4z" clipRule="evenodd" />
+                          </svg>
+                        </button>
 
                         <button
                           onClick={() => removeScreening(id)}

--- a/src/lib/icsCalendar.ts
+++ b/src/lib/icsCalendar.ts
@@ -1,0 +1,164 @@
+import type { Film, Screening, Venue } from "@/lib/types";
+
+export interface CalendarScreening {
+  screening: Screening;
+  film: Film;
+  venue: Venue | undefined;
+}
+
+const CRLF = "\r\n";
+
+/** Escape text values per RFC 5545 */
+function escapeText(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\n/g, "\\n");
+}
+
+/** Fold lines longer than 75 octets per RFC 5545 */
+function foldLine(line: string): string {
+  const maxLen = 75;
+  if (line.length <= maxLen) return line;
+  const parts: string[] = [line.slice(0, maxLen)];
+  let i = maxLen;
+  while (i < line.length) {
+    parts.push(" " + line.slice(i, i + maxLen - 1));
+    i += maxLen - 1;
+  }
+  return parts.join(CRLF);
+}
+
+/** Format date+time as iCal local datetime: YYYYMMDDTHHMMSS */
+function formatDateTime(date: string, time: string): string {
+  // date: YYYY-MM-DD, time: HH:MM
+  return date.replace(/-/g, "") + "T" + time.replace(/:/g, "") + "00";
+}
+
+/** Current UTC timestamp in iCal format */
+function nowUtc(): string {
+  const d = new Date();
+  return (
+    d.getUTCFullYear().toString() +
+    String(d.getUTCMonth() + 1).padStart(2, "0") +
+    String(d.getUTCDate()).padStart(2, "0") +
+    "T" +
+    String(d.getUTCHours()).padStart(2, "0") +
+    String(d.getUTCMinutes()).padStart(2, "0") +
+    String(d.getUTCSeconds()).padStart(2, "0") +
+    "Z"
+  );
+}
+
+function buildVTimezone(): string[] {
+  return [
+    "BEGIN:VTIMEZONE",
+    "TZID:Asia/Hong_Kong",
+    "BEGIN:STANDARD",
+    "DTSTART:19700101T000000",
+    "TZOFFSETFROM:+0800",
+    "TZOFFSETTO:+0800",
+    "TZNAME:HKT",
+    "END:STANDARD",
+    "END:VTIMEZONE",
+  ];
+}
+
+function buildVEvent(
+  screening: Screening,
+  film: Film,
+  venue: Venue | undefined,
+  locale: "en" | "zh",
+  stamp: string
+): string[] {
+  const lines: string[] = [
+    "BEGIN:VEVENT",
+    `UID:${screening.id}@hkiff.herballemon.dev`,
+    `DTSTAMP:${stamp}`,
+    `DTSTART;TZID=Asia/Hong_Kong:${formatDateTime(screening.date, screening.time)}`,
+    `DURATION:PT${film.runtime ?? 120}M`,
+    foldLine(`SUMMARY:${escapeText(film.title[locale])}`),
+  ];
+
+  if (venue) {
+    const location = `${venue.name[locale]}, ${venue.address[locale]}`;
+    lines.push(foldLine(`LOCATION:${escapeText(location)}`));
+  }
+
+  const directorLabel = locale === "zh" ? "導演" : "Dir.";
+  const descParts = [
+    `[${screening.screeningCode}]`,
+    `${directorLabel}: ${film.director[locale]}`,
+  ];
+  if (screening.ticketUrl) {
+    descParts.push(screening.ticketUrl);
+  }
+  lines.push(
+    foldLine(`DESCRIPTION:${escapeText(descParts.join("\\n"))}`)
+  );
+
+  if (screening.ticketUrl) {
+    lines.push(foldLine(`URL:${screening.ticketUrl}`));
+  }
+
+  lines.push("STATUS:CONFIRMED");
+  lines.push("END:VEVENT");
+  return lines;
+}
+
+function buildVCalendar(
+  events: string[][],
+  locale: "en" | "zh"
+): string {
+  const calName = locale === "zh" ? "我的 HKIFF 50 計劃" : "My HKIFF 50 Plan";
+  const lines: string[] = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//HKIFF50//Plan//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    foldLine(`X-WR-CALNAME:${escapeText(calName)}`),
+    ...buildVTimezone(),
+  ];
+  for (const event of events) {
+    lines.push(...event);
+  }
+  lines.push("END:VCALENDAR");
+  return lines.map((l) => foldLine(l)).join(CRLF) + CRLF;
+}
+
+/** Generate .ics content for the entire plan */
+export function generateIcsForPlan(
+  items: CalendarScreening[],
+  locale: "en" | "zh"
+): string {
+  const stamp = nowUtc();
+  const events = items.map(({ screening, film, venue }) =>
+    buildVEvent(screening, film, venue, locale, stamp)
+  );
+  return buildVCalendar(events, locale);
+}
+
+/** Generate .ics content for a single screening */
+export function generateIcsForScreening(
+  screening: Screening,
+  film: Film,
+  venue: Venue | undefined,
+  locale: "en" | "zh"
+): string {
+  const stamp = nowUtc();
+  const event = buildVEvent(screening, film, venue, locale, stamp);
+  return buildVCalendar([event], locale);
+}
+
+/** Trigger a .ics file download in the browser */
+export function downloadIcsFile(content: string, filename: string): void {
+  const blob = new Blob([content], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
This PR adds the ability to export film screenings to calendar applications (`.ics` format). Users can now add their entire HKIFF 50 plan or individual screenings to their calendar with a single click.

## Key Changes
- **New `icsCalendar.ts` module**: Implements RFC 5545-compliant iCalendar generation with:
  - Text escaping and line folding per RFC 5545 standards
  - Support for both full plan and individual screening exports
  - Bilingual calendar names (English/Chinese)
  - Timezone support for Asia/Hong_Kong
  - Browser-based `.ics` file download functionality

- **Updated `PlanPageClient.tsx`**: 
  - Added "Add to Calendar" button for the entire plan (exports as `hkiff50-plan.ics`)
  - Added calendar icon button for individual screenings (exports as `hkiff50-{screeningCode}.ics`)
  - Both buttons respect the current locale setting

- **Updated translations**:
  - Added `addToCalendar` and `addToCalendarSingle` keys to both English and Chinese message files

## Implementation Details
- Calendar events include screening details: title, date/time, venue location, director, screening code, and ticket URL
- Events are created with proper timezone handling (Asia/Hong_Kong)
- Duration is set from film runtime data (defaults to 120 minutes)
- Generated `.ics` files are RFC 5545 compliant and compatible with major calendar applications
- Buttons are disabled when no screenings are in the plan

https://claude.ai/code/session_01BtFEZreN8r4XFp8cKYvQfT